### PR TITLE
基础镜像改为debian，直接集成安装好chromium，所有功能支持amd64,arm64,armv7三大平台。

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,8 @@ RUN cd /tmp \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
     && rm -rf /tmp/*
-COPY normal-rootfs /
-ENTRYPOINT ["/init"]
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
 WORKDIR /config
 VOLUME ["/config", "/media"]
 

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,14 +1,16 @@
-FROM ubuntu
+FROM debian
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
        ca-certificates \
+       chromium \
        dbus-x11 \
        dumb-init \
        ffmpeg \
        fonts-liberation \
        fonts-noto-cjk \
        fonts-noto-color-emoji \
+       gosu \
        gtk2-engines-pixbuf \
        imagemagick \
        libasound2 \
@@ -19,6 +21,7 @@ RUN apt-get update \
        libstdc++6 \
        libxss1 \
        libxtst6 \
+       tini \
        tzdata \
        wget \
        x11-apps \
@@ -30,10 +33,10 @@ RUN apt-get update \
        xorg \
        xvfb \
        yasm \
+    && ln -s /usr/bin/chromium /usr/bin/chrome \
     && apt-get clean \
     && rm -rf \
        /tmp/* \
        /var/lib/apt/lists/* \
        /var/tmp/*
-COPY --from=nevinee/s6-overlay:2.2.0.3-bin-is-softlink / /
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,18 +1,7 @@
-#!/usr/bin/with-contenv bash
-
-## 软连接chrome
-if [[ -n $(ls /root/.cache/rod/browser 2>/dev/null) ]]; then
-    target_chrome=/root/.cache/rod/browser/$(ls -t /root/.cache/rod/browser | head -1)/chrome-linux/chrome
-    if [[ -L /usr/bin/chrome && $(readlink -f /usr/bin/chrome) != $target_chrome ]]; then
-        rm -f /usr/bin/chrome
-        ln -s $target_chrome /usr/bin/chrome &>/dev/null
-    elif [[ ! -e /usr/bin/chrome ]]; then
-        ln -s $target_chrome /usr/bin/chrome &>/dev/null
-    fi
-fi
+#!/bin/bash
 
 ## 重设权限
-chown -R "${PUID}:${PGID}" /config /root
+chown -R "${PUID}:${PGID}" /config
 if [[ ${PERMS} == true ]]; then
     echo "已设置 PERMS=true，重设 '/media' 目录权限为 ${PUID}:${PGID} 所有..."
     chown -R ${PUID}:${PGID} /media
@@ -26,7 +15,7 @@ if [[ -d /app/cache ]]; then
         rm -rf /config/cache &>/dev/null
     fi
     if [[ ! -e /config/cache ]]; then
-        s6-setuidgid ${PUID}:${PGID} ln -sf /app/cache /config/cache
+        gosu ${PUID}:${PGID} ln -sf /app/cache /config/cache
     fi
 else
     if [[ -L /config/cache ]]; then
@@ -34,3 +23,9 @@ else
         rm -rf /config/cache &>/dev/null
     fi
 fi
+
+## 启动
+umask ${UMASK}
+cd /config
+Xvfb -ac ${DISPLAY} -screen 0 1280x1024x16 &
+gosu ${PUID}:${PGID} chinesesubfinder

--- a/docker/normal-rootfs/etc/services.d/chinesesubfinder/run
+++ b/docker/normal-rootfs/etc/services.d/chinesesubfinder/run
@@ -1,6 +1,0 @@
-#!/usr/bin/with-contenv bash
-
-umask ${UMASK}
-
-cd /config 
-exec s6-setuidgid ${PUID}:${PGID} chinesesubfinder

--- a/docker/normal-rootfs/etc/services.d/xvfb/run
+++ b/docker/normal-rootfs/etc/services.d/xvfb/run
@@ -1,3 +1,0 @@
-#!/usr/bin/with-contenv bash
-
-exec Xvfb -ac ${DISPLAY} -screen 0 1280x1024x16


### PR DESCRIPTION
基础镜像改为debian，直接集成安装好chromium，体积虽然增大了，但是无需在每次启动时下载chrome了。并且，所有功能都支持amd64,arm64,armv7三大平台。